### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Python SDK client library (not a runnable application). There are no services to start — the SDK talks to remote Conductor Quantum APIs.
+
+### Quick reference
+
+- **Package manager**: Poetry (`poetry install` to set up)
+- **Lint**: `poetry run ruff check src/ tests/` and `poetry run ruff format --check src/ tests/`
+- **Type check**: `poetry run mypy .`
+- **Unit tests** (offline, mocked HTTP): `poetry run pytest tests/ --ignore=tests/custom/test_models_integration.py --ignore=tests/custom/test_coda_integration.py -v`
+- **Integration tests** (needs API keys): `poetry run pytest tests/custom/test_models_integration.py tests/custom/test_coda_integration.py -v`
+- **Full local CI**: `bash scripts/local_check_ci.sh` (add `--integration` for integration tests)
+
+### Gotchas
+
+- Poetry must be on `PATH`. If missing, run: `pip install poetry` and ensure `$HOME/.local/bin` is on `PATH`.
+- `ruff check` currently has **9 pre-existing I001 (import sort) errors** in test files and Fern-generated test assets. These are known and not regressions.
+- Integration tests require `CONDUCTOR_QUANTUM_API_KEY` env var. The Control API token and Coda API token (must start with `coda_`) are both derived from this key (see `tests/conftest.py`).
+- The `tests/custom/test_client.py::test_client` test is `SKIPPED (Unimplemented)` — this is expected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future cloud agents.

### What's included

- Quick reference for all dev commands (lint, type check, unit tests, integration tests, full CI)
- Gotchas: Poetry PATH setup, pre-existing ruff I001 lint errors, API key requirements, skipped test
- No code modifications — only adds developer documentation

### Environment verification

All development workflows were verified:

- **Type checking** (`mypy .`): 0 issues across 61 source files
- **Unit tests** (`pytest`): 84 passed, 1 skipped (expected)  
- **Lint** (`ruff check/format`): 9 pre-existing I001 import sort issues in test files (not introduced by this PR)
- **SDK hello world**: All components (sync/async clients, Control API, Coda API, numpy integration, token validation) load and work correctly

SDK hello world output:
[sdk_hello_world.log](https://cursor.com/agents/bc-159fde49-c1e6-40db-a3fd-4a96a62eb9d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsdk_hello_world.log)

Unit test results:
[unit_tests.log](https://cursor.com/agents/bc-159fde49-c1e6-40db-a3fd-4a96a62eb9d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funit_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-159fde49-c1e6-40db-a3fd-4a96a62eb9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159fde49-c1e6-40db-a3fd-4a96a62eb9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

